### PR TITLE
mod: ReadMe file according to latest docker compose version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.postgres-data/

--- a/README.md
+++ b/README.md
@@ -24,17 +24,14 @@ go build && ./reverse-hash-service
 ## Run service with docker-compose.yml file
 
 ```console
-# Run docker-compose
-docker-compose up -d
+# Run docker compose
+docker compose up -d
 
 # Copy schema.sql to container with postgres
-docker cp schema.sql <db_container_name>:/
+docker cp schema.sql reverse-hash-service-db-1:/
 
 # Exec to container
-docker exec -it <db_container_name> /bin/bash
-
-# Create rhs db
-createdb -U iden3 -h localhost rhs 
+docker exec -it reverse-hash-service-db-1 /bin/bash
 
 # Upload schema.sql inside on docker container
 psql -h localhost -U iden3  -d rhs < schema.sql


### PR DESCRIPTION
Hello Team

In today's docker engine:`1.48`, `compose` sub-command is already available. So we do not need to install `docker-compose` binary differently.

In this commit, I have done:
- Modified `Readme.md` to use `docker compose` command instead of `docker-compose`.
- Replace `<db_container_name>` with the actual db name i.e `reverse-hash-service-db-1`. 
- Remove `# Create rhs db` section because `rhs` database is initially created from `docker-compose.yml` file.
- Added `.gitignore` file to add `.postgres-data/` in git ignore list.

> Note: I have tested this in Ubuntu System using docker engine version `1.48`.